### PR TITLE
67: Link from Drivers Table to individual Driver Page

### DIFF
--- a/src/components/table/index.tsx
+++ b/src/components/table/index.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactElement } from 'react'
+import { FC, MouseEvent, ReactElement } from 'react'
 
 import { TableBody } from './sub-components/table-body'
 import { TableFooter } from './sub-components/table-footer'
@@ -13,6 +13,7 @@ interface ITableProps {
   sticky?: 'header' | 'footer' | 'both'
   rows: IRow<string | ReactElement>[]
   showCounter?: boolean
+  onRowClick?: (e: MouseEvent<HTMLTableRowElement>, rowId: string) => unknown
 }
 
 export const Table: FC<ITableProps> = ({
@@ -23,6 +24,7 @@ export const Table: FC<ITableProps> = ({
   sticky,
   rows,
   showCounter,
+  onRowClick,
 }) => {
   return (
     <>
@@ -37,7 +39,7 @@ export const Table: FC<ITableProps> = ({
             sticky={sticky && sticky !== 'footer'}
           />
           {rows.length > 0 ? (
-            <TableBody rows={rows} />
+            <TableBody onRowClick={onRowClick} rows={rows} />
           ) : (
             <p className="p-2">No posts found matching this filter.</p>
           )}

--- a/src/components/table/sub-components/table-body.tsx
+++ b/src/components/table/sub-components/table-body.tsx
@@ -1,17 +1,18 @@
-import { FC, ReactElement } from 'react'
+import { FC, MouseEvent, ReactElement } from 'react'
 
 import { IRow } from '../types'
 import { TableRow } from './table-row'
 
 interface ITableBodyProps {
   rows: IRow<string | ReactElement>[]
+  onRowClick?: (e: MouseEvent<HTMLTableRowElement>, rowId: string) => unknown
 }
 
-export const TableBody: FC<ITableBodyProps> = ({ rows }) => {
+export const TableBody: FC<ITableBodyProps> = ({ rows, onRowClick }) => {
   return (
     <tbody>
       {rows.map((row, i) => (
-        <TableRow row={row} key={i} />
+        <TableRow onRowClick={onRowClick} row={row} key={i} />
       ))}
     </tbody>
   )

--- a/src/components/table/sub-components/table-row.tsx
+++ b/src/components/table/sub-components/table-row.tsx
@@ -1,15 +1,19 @@
-import { FC, ReactElement } from 'react'
+import { FC, MouseEvent, ReactElement } from 'react'
 
 import { IRow } from '../types'
 
 interface IRowProps {
   row: IRow<string | ReactElement>
+  onRowClick?: (e: MouseEvent<HTMLTableRowElement>, id: string) => unknown
 }
 
-export const TableRow: FC<IRowProps> = ({ row }) => {
+export const TableRow: FC<IRowProps> = ({ row, onRowClick }) => {
   return (
-    <tr className="hover:bg-lightGray ">
-      {row.map((cell) => (
+    <tr
+      className={`hover:bg-lightGray ${onRowClick && 'cursor-pointer'}`}
+      onClick={(e) => onRowClick && onRowClick(e, row.id)}
+    >
+      {row.cells.map((cell) => (
         <TableCell key={cell.id} id={cell.id ?? ''} text={cell.text} />
       ))}
     </tr>

--- a/src/components/table/types.ts
+++ b/src/components/table/types.ts
@@ -11,4 +11,7 @@ export interface ICell<T extends string | ReactElement> {
   text: string
 }
 
-export type IRow<T extends string | ReactElement> = ICell<T>[]
+export type IRow<T extends string | ReactElement> = {
+  cells: ICell<T>[]
+  id: string
+}


### PR DESCRIPTION
Closes #67 

<img width="1338" alt="image" src="https://github.com/user-attachments/assets/9f0b7298-bc0c-4d78-b4b3-82dcbbfb48d4">

Whole row is clickable, will navigate to the drivers page.