### PR TITLE
Fix table height

### DIFF
--- a/src/components/table/index.tsx
+++ b/src/components/table/index.tsx
@@ -29,7 +29,7 @@ export const Table: FC<ITableProps> = ({
   return (
     <>
       <div
-        className={`h-full overflow-y-scroll shadow-md ${border && 'border border-deepBlue border-solid'}`}
+        className={`h-fit overflow-y-scroll shadow-md ${border && 'border border-deepBlue border-solid'}`}
       >
         <table
           className={`${className} w-full border-collapse bg-white table-auto`}


### PR DESCRIPTION
Fixed the height of the table so that when the table doesn't fill the screen, it doesn't stretch:

<img width="1512" alt="Screenshot 2024-10-02 at 10 50 08" src="https://github.com/user-attachments/assets/8e1e228b-1e61-4c91-ac22-79e800b25eb5">

Fixed:
<img width="1512" alt="Screenshot 2024-10-02 at 10 50 50" src="https://github.com/user-attachments/assets/f3e92ca4-5920-440d-a938-e93434b216e7">
